### PR TITLE
Add aws auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Only support KVV2 vault secrets backend.
 
 Add the following to your `pipeline.yml`:
 
+### Example with Vault Token
 ```yml
 steps:
   - command: ls
@@ -22,6 +23,23 @@ steps:
             MY_OTHER_SECRET: secret/path/foo # Where secret/path is the vault path to the secret and foo is the secret key
 ```
 
+### Example with Auth Metadata
+```yml
+steps:
+  - command: ls
+    plugins:
+      - vj396/vault-secrets#v0.1.0:
+          image: 'vault' # optional. Defaults to https://hub.docker.com/_/vault
+          tag: "1.10.2" # optional. Defaults to 1.10.2
+          address: "http://vault-server:8200" # optional. plugin will error when VAULT_ADDR is also not in env.
+          auth:
+            method: aws # optional. defaults to vault login method `aws`
+            role: example-role # optional. defaults to vault aws auth role `buildkite`
+            path: aws/custom/path # optional. Vault Auth backend path. defaults to `aws`
+          env:
+            MY_SECRET: secret/foo # where foo is the secret key
+            MY_OTHER_SECRET: secret/path/foo # Where secret/path is the vault path to the secret and foo is the secret key
+```
 ## Developing
 
 ### Test

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ steps:
             method: aws # optional. defaults to vault login method `aws`
             role: example-role # optional. defaults to vault aws auth role `buildkite`
             path: aws/custom/path # optional. Vault Auth backend path. defaults to `aws`
+            header: vault.service.consul # optional. Defaults to vault_addr server name
           env:
             MY_SECRET: secret/foo # where foo is the secret key
             MY_OTHER_SECRET: secret/path/foo # Where secret/path is the vault path to the secret and foo is the secret key

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+_source="${BASH_SOURCE[0]}"
+[ -z "${_source:-}" ] && _source="${0}"
+basedir="$( cd "$( dirname "${_source}" )" && cd .. && pwd )"
+
+# shellcheck disable=SC1090
+. "$basedir/lib/shared.sh"
+
 readonly default_image="vault"
 readonly default_tag="1.10.2"
 readonly image="${BUILDKITE_PLUGIN_VAULT_SECRETS_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_VAULT_SECRETS_TAG:-${default_tag}}"
@@ -11,11 +18,17 @@ readonly container_name="vault-secrets-env-plugin-${BUILDKITE_JOB_ID}"
 ########################################################################
 if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_TOKEN:-}" ]; then
     VAULT_TOKEN="${BUILDKITE_PLUGIN_VAULT_SECRETS_TOKEN}"
-    export VAULT_ADDR
+    export VAULT_TOKEN
 fi
+
 if [ -z "${VAULT_TOKEN:-}" ]; then
+  if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-"aws"}" ]; then
+    vault_auth_${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_METHOD:-"aws"}
+  fi
+  if [ -z "${VAULT_TOKEN:-}" ]; then
     echo "--- :skull_and_crossbones: Could not find 'VAULT_TOKEN' in the environment!"
     exit 1
+  fi
 fi
 
 # Resolve Vault address
@@ -28,50 +41,6 @@ if [ -z "${VAULT_ADDR:-}" ]; then
     echo "--- :skull_and_crossbones: Could not find 'VAULT_ADDR' in the environment, and 'BUILDKITE_PLUGIN_VAULT_SECRETS_ADDRESS' was not specified!"
     exit 1
 fi
-
-# Helper Functions
-function strip_quotes() {
-  echo "${1}" | sed "s/^[[:blank:]]*//g;s/[[:blank:]]*$//g;s/[\"']//g"
-}
-
-cleanup() {
-    docker container rm --force "${container_name}" > /dev/null 2>&1
-}
-
-function get_secret_value() {
-  local secretPath="$1"
-  local secretKey="$2"
-  local secrets;
-  cleanup
-  echo -e "\033[31m" >&2
-  secrets=$(docker run \
-      --cap-add IPC_LOCK \
-      --env VAULT_TOKEN="${VAULT_TOKEN}" \
-      --name="${container_name}" \
-      -- \
-      "${image}" \
-      vault kv get \
-      -address "${VAULT_ADDR}" \
-      -format=json \
-      "${secretPath}")
-  local result=$?
-  echo -e "\033[0m" >&2
-  if [[ $result -ne 0 ]]; then
-    docker container logs "${container_name}"
-    exit 1
-  fi
-  echo "${secrets}" | jq -r .data.data."${secretKey}"
-}
-
-load_secret_into_env() {
-  local export_name="$1"
-  local secret_path="$2"
-  local secret_key="$3"
-  local secret_value
-  echo "Reading ${secret_path}/${secret_key} from Vault into environment variable ${export_name}"
-  secret_value="$(get_secret_value "${secret_path}" "${secret_key}")"
-  export "${export_name}=${secret_value}"
-}
 
 # main logic
 trap cleanup EXIT INT QUIT

--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -33,7 +33,7 @@ function vault_auth_aws() {
 }
 EOF
 )
-  response=$(curl --request POST --fail --data "$data" "$auth_url")
+  response=$(curl --request POST --fail-with-body --data "$data" "$auth_url")
   export VAULT_TOKEN=$(echo $response | jq -r .auth.client_token)
 }
 

--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -19,6 +19,8 @@ function vault_auth_aws() {
   if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_HEADER:-${VAULT_ADDR}}" ]; then
     VAULT_IAM_SERVER_HEADER=$(echo ${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_HEADER:-${VAULT_ADDR}} | sed 's/.*:\/\///' | sed 's/:.*//' | sed 's/\/.*//')
   fi
+  echo "--- Auth URL: ${auth_url}"
+  echo "--- Vault IAM Server Header: ${VAULT_IAM_SERVER_HEADER}"
   signed_request=$(python ${SIGN_REQUEST_FILE_PATH} ${VAULT_IAM_SERVER_HEADER})
   iam_request_url=$(echo $signed_request | jq -r .iam_request_url)
   iam_request_body=$(echo $signed_request | jq -r .iam_request_body)
@@ -34,6 +36,7 @@ function vault_auth_aws() {
 EOF
 )
   response=$(curl --request POST --data "$data" "$auth_url")
+  echo "--- Response: ${response}"
   export VAULT_TOKEN=$(echo $response | jq -r .auth.client_token)
 }
 

--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -19,8 +19,6 @@ function vault_auth_aws() {
   if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_HEADER:-${VAULT_ADDR}}" ]; then
     VAULT_IAM_SERVER_HEADER=$(echo ${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_HEADER:-${VAULT_ADDR}} | sed 's/.*:\/\///' | sed 's/:.*//' | sed 's/\/.*//')
   fi
-  echo "--- Auth URL: ${auth_url}"
-  echo "--- Vault IAM Server Header: ${VAULT_IAM_SERVER_HEADER}"
   signed_request=$(python ${SIGN_REQUEST_FILE_PATH} ${VAULT_IAM_SERVER_HEADER})
   iam_request_url=$(echo $signed_request | jq -r .iam_request_url)
   iam_request_body=$(echo $signed_request | jq -r .iam_request_body)
@@ -35,8 +33,7 @@ function vault_auth_aws() {
 }
 EOF
 )
-  response=$(curl --request POST --data "$data" "$auth_url")
-  echo "--- Response: ${response}"
+  response=$(curl --request POST --fail --data "$data" "$auth_url")
   export VAULT_TOKEN=$(echo $response | jq -r .auth.client_token)
 }
 

--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+SIGN_REQUEST_FILE_URL="https://raw.githubusercontent.com/hashicorp/terraform-aws-vault/master/examples/vault-consul-ami/auth/sign-request.py"
+SIGN_REQUEST_FILE_PATH="${HOME}/.custom/sign_requests.py"
+function download_request_signer_script() {
+  if [ ! -d "$HOME/.custom" ]; then
+    mkdir -p $HOME/.custom
+  fi
+  if [ ! -f "${SIGN_REQUEST_FILE_PATH}" ]; then
+    echo "--- downloading sign_requests.py from ${SIGN_REQUEST_FILE_URL}"
+    curl -sL -o $SIGN_REQUEST_FILE_PATH $SIGN_REQUEST_FILE_URL
+  fi
+}
+
+function vault_auth_aws() {
+  # parse auth data
+  download_request_signer_script
+  auth_url="${VAULT_ADDR}/v1/auth"
+  if [ -n "${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_PATH:-"aws"}" ]; then
+    auth_url="${auth_url}/${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_PATH:-"aws"}/login"
+  fi
+  VAULT_IAM_SERVER_HEADER=$(echo ${VAULT_ADDR} | sed 's/.*:\/\///' | sed 's/:.*//' | sed 's/\/.*//')
+  signed_request=$(python ${SIGN_REQUEST_FILE_PATH} ${VAULT_IAM_SERVER_HEADER})
+  iam_request_url=$(echo $signed_request | jq -r .iam_request_url)
+  iam_request_body=$(echo $signed_request | jq -r .iam_request_body)
+  iam_request_headers=$(echo $signed_request | jq -r .iam_request_headers)
+  data=$(cat <<EOF
+{
+  "role":"${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE:-"buildkite"}",
+  "iam_http_request_method": "POST",
+  "iam_request_url": "$iam_request_url",
+  "iam_request_body": "$iam_request_body",
+  "iam_request_headers": "$iam_request_headers"
+}
+EOF
+)
+  response=$(curl --request POST --data "$data" "$auth_url")
+  export VAULT_TOKEN=$(echo $response | jq -r .auth.client_token)
+}
+
+function strip_quotes() {
+  echo "${1}" | sed "s/^[[:blank:]]*//g;s/[[:blank:]]*$//g;s/[\"']//g"
+}
+
+cleanup() {
+    docker container rm --force "${container_name}" > /dev/null 2>&1
+}
+
+function get_secret_value() {
+  local secretPath="$1"
+  local secretKey="$2"
+  local secrets;
+  cleanup
+  echo -e "\033[31m" >&2
+  secrets=$(docker run \
+      --cap-add IPC_LOCK \
+      --env VAULT_TOKEN="${VAULT_TOKEN}" \
+      --name="${container_name}" \
+      -- \
+      "${image}" \
+      vault kv get \
+      -address "${VAULT_ADDR}" \
+      -format=json \
+      "${secretPath}")
+  local result=$?
+  echo -e "\033[0m" >&2
+  if [[ $result -ne 0 ]]; then
+    docker container logs "${container_name}"
+    exit 1
+  fi
+  echo "${secrets}" | jq -r .data.data."${secretKey}"
+}
+
+load_secret_into_env() {
+  local export_name="$1"
+  local secret_path="$2"
+  local secret_key="$3"
+  local secret_value
+  echo "Reading ${secret_path}/${secret_key} from Vault into environment variable ${export_name}"
+  secret_value="$(get_secret_value "${secret_path}" "${secret_key}")"
+  export "${export_name}=${secret_value}"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,9 @@ configuration:
     token:
       type: string
       description: The `vault` token that will be used to fetch secrets. (corresponds to 'VAULT_TOKEN')
+    auth:
+      description: An object map of auth metadata to authenticate with vault and fetch a vault token
+      type: object
     env:
       description: An object map of secrets to inject into the environment
       type: object


### PR DESCRIPTION
Add aws auth support for buildkite plugin.

relies heavily on [sign_requests.py](https://github.com/hashicorp/terraform-aws-vault/blob/master/examples/vault-consul-ami/auth/sign-request.py)