### PR TITLE
Print errors returned from Vault when we try to get a VAULT_TOKEN

### DIFF
--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -33,7 +33,11 @@ function vault_auth_aws() {
 }
 EOF
 )
-  response=$(curl --request POST --fail-with-body --data "$data" "$auth_url")
+  if ! response=$(curl --request POST --fail-with-body --data "$data" "$auth_url");
+  then
+    echo "Request for Vault token failed with response body: $response"
+    exit 1
+  fi
   export VAULT_TOKEN=$(echo $response | jq -r .auth.client_token)
 }
 


### PR DESCRIPTION
This will give us some information to help debug failures like the one we're seeing at https://buildkite.com/curative-inc/member-status-pages-build/builds/2077#01835f4e-7792-4fbb-91d4-e0d428fd66f5.

I tested this over at https://github.com/curative/covid19lab/pull/12976 and it appears to work (though the response body returned by Vault in that case is, uh, not enormously helpful).